### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,13 +145,13 @@ Credits
 Thanks to Jason Orendorff on for the idea on stackoverflow. I also want
 to thank @coldfix and @Moredread for contributions and feedback.
 
-.. |Downloads| image:: https://pypip.in/d/obsub/badge.png
+.. |Downloads| image:: https://img.shields.io/pypi/dm/obsub.svg
    :target: https://pypi.python.org/pypi/obsub/
    :alt: Downloads
-.. |Version| image:: https://pypip.in/v/obsub/badge.png
+.. |Version| image:: https://img.shields.io/pypi/v/obsub.svg
    :target: https://pypi.python.org/pypi/obsub/
    :alt: Latest Version
-.. |License| image:: https://pypip.in/license/obsub/badge.png
+.. |License| image:: https://img.shields.io/pypi/l/obsub.svg
    :target: https://pypi.python.org/pypi/obsub/
    :alt: License
 .. |Build Status| image:: https://api.travis-ci.org/aepsil0n/obsub.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20obsub))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `obsub`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.